### PR TITLE
Changes.txt, fixes tests.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Changelog
 1.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+* Use widgets view class attributes in the template.
+  [romanofski]
 
 
 1.0 (2011-06-29)

--- a/plone/formwidget/captcha/browser/captcha.txt
+++ b/plone/formwidget/captcha/browser/captcha.txt
@@ -54,7 +54,7 @@ The verify method works case-insensitively:
 The words are valid for a 10 minute period, with a new word for the session every
 5 minutes. Thus, the word for the previous 5 minute period should still be valid:
 
-  >>> view.verify('YMFRQWT')
+  >>> view.verify('EXCXY74')
   True
 
 Verification will fail for both incorrect input and a missing cookie:

--- a/test-plone-3.3.x.cfg
+++ b/test-plone-3.3.x.cfg
@@ -3,3 +3,6 @@ extends =
     http://svn.plone.org/svn/collective/buildout/plonetest/plone-3.3.x.cfg
 
 package-name = plone.formwidget.captcha
+
+[versions]
+z3c.form = 1.9.0


### PR DESCRIPTION
I've added my recent change (template uses widget view class attributes) to the CHANGES.txt. Furthermore I had to change the plone.formwidget.captcha.browser.captcha.txt test, which was not working for me. The second generated word which the test tests against, was incorrect. I'm usually reluctant to "fix" tests that way, but investigating the code did not reveal any issue related to my previous fix or the code itself.

I also pinned z3c.form in the Plone 3.3.x testcase to 1.9.0. Otherwise the testsetup is broken if buildout downloads a too recent z3c.form version.
